### PR TITLE
Make this repo obsolete

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+# THIS REPO IS OBSOLETE AND HAS BITROTTED
+
 The OpenStax landing page (openstax.org).
 
 * `bundle exec middleman build` to generate the static (compiled) version of the site in the `build` directory


### PR DESCRIPTION
Maybe we could delete it or change the name? or create a `openstax-archived` org and move this to it?
